### PR TITLE
 Sets default microphone role to user.

### DIFF
--- a/src/app/states/device.service.ts
+++ b/src/app/states/device.service.ts
@@ -138,7 +138,10 @@ export class DeviceService {
         (s) => s.deviceId === input.deviceId,
       );
       if (microphoneState) {
-        states.push(microphoneState);
+        states.push({
+          ...microphoneState,
+          role: microphoneState.role ?? 'user',
+        });
       } else {
         states.push({
           deviceId: input.deviceId,


### PR DESCRIPTION
 Without this default value, f6cb23 broke previous microphone settings leading
 to a rendering error of input messages (in `transcript.component.html` when setting
 the `[ngClass]` on line 16).