### PR TITLE
feat: improve scroll behavior with ongoing text, improve styling of p…

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,7 +21,8 @@
       [systemMessage]="state.systemMessage"
       class="flex-grow min-h-0"></app-transcript>
 
-      <app-override-lane class="shrink"></app-override-lane>
-      <app-prerecoding-lane class="h-1/4 flex-shrink-0"></app-prerecoding-lane>
+      <app-override-lane class="shrink" *ngIf="overrideMode$ | async"></app-override-lane>
+      <app-prerecoding-lane class="h-1/4 flex-shrink-0" [allowEdit]="overrideMode$ | async"
+                            [allowDelete]="liveEditMode$ | async"></app-prerecoding-lane>
   </div>
 </ng-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,13 @@
 import {Component, ViewContainerRef} from '@angular/core';
 import {ModalService} from './modules/modal/modal.service';
 import {ConfigurationSidebarComponent} from './components/configuration-sidebar/configuration-sidebar.component';
-import {firstValueFrom} from 'rxjs';
+import { firstValueFrom, map } from "rxjs";
 import {ChanDaLiarService} from './states/chan-da-liar.service';
 import {OpenAiService} from './states/open-ai.service';
 import {ConversationService} from './states/conversation.service';
 import { faGear } from '@fortawesome/free-solid-svg-icons';
 import { OngoingRecognition } from './states/ongoing-recognizer';
+import { AppService } from "./states/app.service";
 
 @Component({
   selector: 'app-root',
@@ -17,12 +18,15 @@ export class AppComponent {
   settingsIcon = faGear;
 
   state$ = this.chanDaLiar.state$;
+  overrideMode$ = this.app.state$.pipe(map(state => state.overrideMode));
+  liveEditMode$ = this.app.state$.pipe(map(state => state.overrideMode && state.livePresetEdit))
 
   constructor(
     private modal: ModalService,
     private viewContainerRef: ViewContainerRef,
     private openAI: OpenAiService,
     private chanDaLiar: ChanDaLiarService,
+    private app: AppService,
     private conversation: ConversationService
   ) {
     firstValueFrom(this.state$).then((state) => {

--- a/src/app/components/button/button.component.html
+++ b/src/app/components/button/button.component.html
@@ -1,5 +1,5 @@
 <button
-  class="text-white rounded-md px-3 disabled:bg-gray-400 py-2 w-full"
+  class="text-white h-full rounded-md px-3 disabled:bg-gray-400 py-2 w-full"
   [ngClass]="type === 'dangerous' ? ['bg-orange-500'] : ['bg-teal-500']"
   [disabled]="disabled">
   <ng-content></ng-content>

--- a/src/app/components/configuration-prerecording-list-sidebar/configuration-prerecording-list-sidebar.component.html
+++ b/src/app/components/configuration-prerecording-list-sidebar/configuration-prerecording-list-sidebar.component.html
@@ -1,9 +1,6 @@
 <ng-container *ngIf="state$ | async as state">
-  <div class="flex flex-col flex-grow min-h-0 space-y-3">
-    <app-button *ngFor="let recording of state.recordings; let index = index" class="truncate"
-                (click)="edit(index, recording)">
-      {{recording.content}}
-    </app-button>
+  <div class="flex flex-col overflow-y-auto flex-grow min-h-0 space-y-3">
+    <app-prerecoding-lane [allowEdit]="true" [allowDelete]="true" [editMode]="'sidepanel'" class="flex-grow min-h-0"></app-prerecoding-lane>
   </div>
 
   <app-button (click)="create()">Create</app-button>

--- a/src/app/components/configuration-prerecording-sidebar/configuration-prerecording-sidebar.component.html
+++ b/src/app/components/configuration-prerecording-sidebar/configuration-prerecording-sidebar.component.html
@@ -1,5 +1,5 @@
 <app-textarea
-  #transcript
+  #transcript [heading]="'Content'"
   class="flex-grow min-h-0"
   [value]="content"></app-textarea>
 <app-voice-processor

--- a/src/app/components/configuration-prerecording-sidebar/configuration-prerecording-sidebar.component.scss
+++ b/src/app/components/configuration-prerecording-sidebar/configuration-prerecording-sidebar.component.scss
@@ -1,3 +1,3 @@
 :host {
-  @apply flex flex-col px-8 space-y-4 h-full pb-8;
+  @apply flex flex-col px-8 space-y-4 h-full pb-8 flex-grow min-h-0;
 }

--- a/src/app/components/configuration-sidebar/configuration-sidebar.component.html
+++ b/src/app/components/configuration-sidebar/configuration-sidebar.component.html
@@ -7,6 +7,36 @@
       *ngFor="let configuration of configurations"
       [component]="configuration.component"
       [state]="configuration.state"></app-configuration-item>
+
+
+    <ng-container *ngIf="appState$ | async as appState">
+      <app-box-container class="flex justify-between space-x-3">
+        <app-explaination
+          [heading]="'Override Mode'"
+          [description]="'Type responses by keyboard'">
+        </app-explaination>
+
+        <app-toggle
+          tabindex="-1"
+          [enabled]="appState.overrideMode"
+          (enabledChanged)="setOverrideMode($event)">
+        </app-toggle>
+      </app-box-container>
+
+      <app-box-container class="flex justify-between space-x-3" *ngIf="appState.overrideMode">
+        <app-explaination
+          [heading]="'Live Edit Mode'"
+          [description]="'Edit responses by keyboard'">
+        </app-explaination>
+
+        <app-toggle
+          tabindex="-1"
+          [enabled]="appState.livePresetEdit"
+          (enabledChanged)="setLiveEdit($event)">
+        </app-toggle>
+      </app-box-container>
+    </ng-container>
+
   </div>
 
   <app-button *ngIf="!state.noneReady" (click)="reset()" [type]="'dangerous'">Reset</app-button>

--- a/src/app/components/configuration-sidebar/configuration-sidebar.component.ts
+++ b/src/app/components/configuration-sidebar/configuration-sidebar.component.ts
@@ -18,6 +18,8 @@ import {
   ConfigurationLightSidebarComponent
 } from '../configuration-light-sidebar/configuration-light-sidebar.component';
 import { LightService } from '../../states/light.service';
+import { map } from "rxjs";
+import { AppService } from "../../states/app.service";
 
 @Component({
   selector: 'app-configuration-sidebar',
@@ -62,11 +64,13 @@ export class ConfigurationSidebarComponent implements ModalInstance<void> {
       description: 'Configure prerecorded answers',
       component: ConfigurationPrerecordingListSidebarComponent,
       state: this.prerecording,
+      classNames: ['fullscreen']
     },
   ];
 
   modal!: ModalHandle<void>;
   state$ = this.chanDaLiar.state$;
+  appState$ = this.app.state$;
 
   constructor(
     private chanDaLiar: ChanDaLiarService,
@@ -77,7 +81,17 @@ export class ConfigurationSidebarComponent implements ModalInstance<void> {
     private azureCognitive: AzureCognitiveService,
     private firebase: FirebaseService,
     private config: ConfigService,
+    private app: AppService
   ) {}
+
+
+  setOverrideMode(developer: boolean) {
+    this.app.setOverrideMode(developer);
+  }
+
+  setLiveEdit(liveEdit: boolean) {
+    this.app.setLivePreset(liveEdit);
+  }
 
   dismiss() {
     this.modal.dismiss();

--- a/src/app/components/microphone-lane/microphone-lane.component.html
+++ b/src/app/components/microphone-lane/microphone-lane.component.html
@@ -1,4 +1,4 @@
-<app-box-container class="flex space-x-3">
+<app-box-container class="flex space-x-3 h-full">
   <app-toggle
     #enabledToggle
     [enabled]="enabledMic"

--- a/src/app/components/override-lane/override-lane.component.html
+++ b/src/app/components/override-lane/override-lane.component.html
@@ -7,12 +7,4 @@
     [value]="value"
     (valueChanged)="valueChanged($event)"
     (keyDown)="keyDown($event)"></app-input>
-  <div class="flex-col items-center">  <!-- ??? toggle is not centered-->
-    <div>Developer</div>
-    <app-toggle
-      tabindex="-1"
-      [enabled]="!!(developer | async)"
-      (enabledChanged)="setDeveloper($event)">
-    </app-toggle>
-  </div>
 </div>

--- a/src/app/components/override-lane/override-lane.component.ts
+++ b/src/app/components/override-lane/override-lane.component.ts
@@ -14,7 +14,6 @@ export class OverrideLaneComponent {
 
   destination: string = 'bot';
   value: string = '';
-  developer = this.app.state$.pipe(map(state => state.developer));
 
   @ViewChild('input', {static: false})
   input?: InputComponent;
@@ -63,9 +62,5 @@ export class OverrideLaneComponent {
         'user': 'bot',
       }[this.destination])!;
     }
-  }
-
-  setDeveloper(developer: boolean) {
-    this.app.setDeveloper(developer);
   }
 }

--- a/src/app/components/prerecoding-lane/prerecoding-lane.component.html
+++ b/src/app/components/prerecoding-lane/prerecoding-lane.component.html
@@ -1,20 +1,20 @@
 <span class="text-gray-400 text-xs mb-1">Prerecordings</span>
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3" *ngIf="state$ | async as state">
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 overflow-y-auto flex-grow min-h-0" *ngIf="state$ | async as state">
   <div
     class="flex items-center space-x-3"
     *ngFor="let rec of state.recordings; let index = index">
-    <div class="relative">
+    <div class="relative flex-grow min-w-0">
       <app-button (click)="play(rec, $event)" class="flex-grow min-w-0">
         <div class="flex items-center space-x-3">
           <fa-icon [icon]="playIcon"></fa-icon>
-          <div class="text-left text-sm">
+          <div class="text-left text-sm truncate">
             {{rec.content}}
           </div>
         </div>
       </app-button>
-      <div class="absolute -bottom-2 right-1 text-teal-800 space-x-2 text-xs">
-        <fa-icon [icon]="modifyIcon" class="cursor-pointer" (click)="modify(index)"></fa-icon>
-        <fa-icon [icon]="deleteIcon" class="cursor-pointer" (click)="delete(index)" *ngIf="developer$ | async"></fa-icon>
+      <div class="absolute -bottom-2 right-1 text-teal-800 space-x-2 text-xs" *ngIf="allowDelete || allowEdit">
+        <fa-icon [icon]="modifyIcon" class="cursor-pointer" (click)="modify(index, rec.content)" *ngIf="allowEdit"></fa-icon>
+        <fa-icon [icon]="deleteIcon" class="cursor-pointer" (click)="delete(index)" *ngIf="allowDelete"></fa-icon>
       </div>
     </div>
   </div>

--- a/src/app/components/prerecoding-lane/prerecoding-lane.component.ts
+++ b/src/app/components/prerecoding-lane/prerecoding-lane.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component, Input, ViewContainerRef } from "@angular/core";
 import { faPlay, faTrashCan, faPen } from '@fortawesome/free-solid-svg-icons';
 import { ModalService } from '../../modules/modal/modal.service';
 import { ConfigurationPrerecordingSidebarComponent } from '../configuration-prerecording-sidebar/configuration-prerecording-sidebar.component';
@@ -20,14 +20,21 @@ export class PrerecodingLaneComponent {
   deleteIcon = faTrashCan;
   modifyIcon = faPen;
 
+  @Input()
+  allowEdit?: boolean | null = false;
+
+  @Input()
+  allowDelete?: boolean | null = false;
+
+  @Input()
+  editMode: 'inline' | 'sidepanel' = 'inline'
+
   state$ = this.prerecording.state$;
-  developer$ = this.app.state$.pipe(map(state => state.developer!));
   constructor(
     private modal: ModalService,
     private prerecording: PrerecordingService,
     private conversation: ConversationService,
     private viewContainerRef: ViewContainerRef,
-    private app: AppService,
   ) {}
 
   openCreate() {
@@ -56,10 +63,14 @@ export class PrerecodingLaneComponent {
     elm.blur();
   }
 
-  async modify(index: number) {
-    // We first emit '' to force an update if the text input was edited.
-    this.prerecording.editable.next('');
-    this.prerecording.editable.next(this.prerecording.get(index).content);
+  async modify(index: number, content: string) {
+    if (this.editMode === 'inline') {
+      // We first emit '' to force an update if the text input was edited.
+      this.prerecording.editable.next('');
+      this.prerecording.editable.next(content);
+    } else {
+      this.edit(index, content)
+    }
   }
 
   async delete(index: number) {

--- a/src/app/components/transcript/transcript.component.ts
+++ b/src/app/components/transcript/transcript.component.ts
@@ -62,7 +62,7 @@ export class TranscriptComponent implements OnInit, AfterViewInit, OnDestroy {
     app: AppService,
   ) {
     app.state$.subscribe(state => {
-      this.developer = state.developer;
+      this.developer = state.overrideMode;
     });
     openai.state$.subscribe(state => {
       this.selectedModel = state.selectedModel?.id ?? '?';

--- a/src/app/modules/modal/modal-sidebar/modal-sidebar.component.html
+++ b/src/app/modules/modal/modal-sidebar/modal-sidebar.component.html
@@ -1,5 +1,5 @@
 <div
-  class="fixed z-100 bg-black h-screen w-screen flex flex-col min-h-0 bg-opacity-40 flex backdrop"
+  class="fixed z-20 bg-black h-screen w-screen flex flex-col min-h-0 bg-opacity-40 flex backdrop"
   [ngClass]="{
     'right-origin': origin === 'right',
     'bottom-origin': origin === 'bottom'

--- a/src/app/states/app.service.ts
+++ b/src/app/states/app.service.ts
@@ -3,25 +3,33 @@ import { ConfigService } from "../config.service";
 import { Observable, combineLatest, map, mergeMap } from "rxjs";
 
 export interface AppState {
-  developer: boolean;
+  overrideMode: boolean;
+  livePresetEdit: boolean
 }
 
 @Injectable({
   providedIn: 'root',
 })
 export class AppService {
-  private configDeveloperKey = 'app-developer';
+  private configOverrideModeKey = 'app-override-mode';
+  private configLivePresetEditKey = 'app-live-preset-edit';
 
   state$: Observable<AppState> = combineLatest([
-    this.config.watch<boolean>(this.configDeveloperKey, false),
+    this.config.watch<boolean>(this.configOverrideModeKey, false),
+    this.config.watch<boolean>(this.configLivePresetEditKey, false),
   ]).pipe(
-    map(([developer]) => ({
-      developer: developer!,
+    map(([overrideMode, livePresetEdit]) => ({
+      overrideMode: !!overrideMode,
+      livePresetEdit: !!livePresetEdit,
     }))
   );
 
-  setDeveloper(developer: boolean) {
-    this.config.save(this.configDeveloperKey, developer);
+  setLivePreset(value: boolean) {
+    this.config.save(this.configLivePresetEditKey, value);
+  }
+
+  setOverrideMode(value: boolean) {
+    this.config.save(this.configOverrideModeKey, value);
   }
 
   constructor(private config: ConfigService) {}

--- a/src/app/states/conversation.service.ts
+++ b/src/app/states/conversation.service.ts
@@ -1,19 +1,19 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, firstValueFrom, map, Observable, shareReplay, Subscription } from 'rxjs';
-import { OpenAiService, OpenAIState, PromptMessage } from './open-ai.service';
-import { Recording } from './prerecording.service';
-import { OngoingRecognition } from './ongoing-recognizer';
-import { SpeakerService } from './speaker.service';
-import { FirebaseService } from './firebase.service';
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, firstValueFrom, map, Observable, shareReplay, Subscription } from "rxjs";
+import { OpenAiService, OpenAIState, PromptMessage } from "./open-ai.service";
+import { Recording } from "./prerecording.service";
+import { OngoingRecognition } from "./ongoing-recognizer";
+import { SpeakerService } from "./speaker.service";
+import { FirebaseService } from "./firebase.service";
 
-export type ConversationRole = 'assistant' | 'user' | 'system';
-export type Decision = 'yes' | 'skip' | 'open';
+export type ConversationRole = "assistant" | "user" | "system";
+export type Decision = "yes" | "skip" | "open";
 
 export interface CompletedConversationMessage {
-  id: number
+  id: number;
   text: string;
   displayedText: string;
-  expandable: boolean
+  expandable: boolean;
   decision: Decision;
   highlight: boolean;
   queued: boolean;
@@ -25,7 +25,7 @@ export interface CompletedConversationMessage {
 }
 
 export interface OngoingConversationMessage {
-  id: number
+  id: number;
   text$: Observable<string>;
   role: ConversationRole;
   textPrefix?: string;
@@ -44,14 +44,14 @@ export type ConversationMessage =
 
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: "root"
 })
 export class ConversationService {
   messageMaxLength = 120;
 
   messagesSubject = new BehaviorSubject<ConversationMessage[]>([]);
   highlightSubject = new BehaviorSubject<CompletedConversationMessage | null>(
-    null,
+    null
   );
   conversationId = Date.now().toString();
   ongoingConversations: OngoingConversationRecognition[] = [];
@@ -59,12 +59,12 @@ export class ConversationService {
   messages$ = this.messagesSubject.asObservable();
 
   highlight$ = this.highlightSubject.asObservable();
-  selectedModel = '?';
+  selectedModel = "?";
 
   constructor(
     private openAI: OpenAiService,
     private speaker: SpeakerService,
-    firebase: FirebaseService,
+    firebase: FirebaseService
   ) {
     this.openAI.state$.subscribe((state) => {
       this.clear(state);
@@ -78,28 +78,28 @@ export class ConversationService {
       }
     });
 
-    window.addEventListener('keydown', (evt) => {
+    window.addEventListener("keydown", (evt) => {
       if (evt.target instanceof HTMLInputElement || evt.target instanceof HTMLTextAreaElement) {
         return;
       }
-      if (evt.code === 'Space') {
+      if (evt.code === "Space") {
         if (this.highlightSubject.value) {
-          this.highlightSubject.value.decision = 'yes';
+          this.highlightSubject.value.decision = "yes";
           this.goToNextPart(this.highlightSubject.value);
           this.messagesSubject.next(this.messagesSubject.value);
         }
-      } else if (evt.code === 'ArrowRight' || evt.code === 'Backspace') {
+      } else if (evt.code === "ArrowRight" || evt.code === "Backspace") {
         if (
           this.highlightSubject.value &&
-          this.highlightSubject.value.decision === 'open'
+          this.highlightSubject.value.decision === "open"
         ) {
-          this.highlightSubject.value.decision = 'skip';
+          this.highlightSubject.value.decision = "skip";
           this.goToNextPart(this.highlightSubject.value);
           this.messagesSubject.next(this.messagesSubject.value);
         }
         evt.preventDefault();
         evt.stopPropagation();
-      } else if (evt.code === 'ArrowLeft') {
+      } else if (evt.code === "ArrowLeft") {
         if (this.highlightSubject.value) {
           // TODO allow back
         }
@@ -111,9 +111,9 @@ export class ConversationService {
     part.highlight = false;
 
     const index = this.messagesSubject.value.indexOf(part);
-    if (part.role === 'user' && part.decision === 'yes') {
+    if (part.role === "user" && part.decision === "yes") {
       this.resolve(index);
-    } else if (part.role === 'assistant' && part.decision === 'yes') {
+    } else if (part.role === "assistant" && part.decision === "yes") {
       this.queue(part);
     }
     if (index < this.messagesSubject.value.length - 1) {
@@ -137,22 +137,22 @@ export class ConversationService {
     this.messagesSubject.next(
       state.rolePlayScript
         ? [
-            {
-              id: Date.now(),
-              displayedText: this.getDisplayText('system', state.rolePlayScript),
-              expandable: this.isExpandable('system', state.rolePlayScript),
-              role: 'system',
-              decision: 'yes',
-              completed: true,
-              highlight: false,
-              played: true,
-              prefix: null,
-              queued: true,
-              text: state.rolePlayScript,
-              model: state.selectedModel?.id,
-            },
-          ]
-        : [],
+          {
+            id: Date.now(),
+            displayedText: this.getDisplayText("system", state.rolePlayScript),
+            expandable: this.isExpandable("system", state.rolePlayScript),
+            role: "system",
+            decision: "yes",
+            completed: true,
+            highlight: false,
+            played: true,
+            prefix: null,
+            queued: true,
+            text: state.rolePlayScript,
+            model: state.selectedModel?.id
+          }
+        ]
+        : []
     );
     this.ongoingConversations = [];
     this.highlightSubject.next(null);
@@ -165,34 +165,34 @@ export class ConversationService {
       if (!message.completed) {
         continue;
       }
-      if (message.decision !== 'yes') {
+      if (message.decision !== "yes") {
         continue;
       }
       promptMessages.push({
         content: !!message.prefix ? `${message.prefix}${message.text}` : message.text,
-        role: message.role,
+        role: message.role
       });
     }
 
     this.openAI.prompt(promptMessages).then(recogniztion => {
-      this.push(recogniztion, untilIndex+1);
-    })
+      this.push(recogniztion, untilIndex + 1);
+    });
   }
 
   pushAssistant(recording: Recording) {
-    const newMessage = this.createCompletedMessage(recording.content, 'assistant', 'yes', null);
+    const newMessage = this.createCompletedMessage(recording.content, "assistant", "yes", null);
     this.queue(newMessage);
-    const lastDecisionIndex = this.messagesSubject.value.findIndex(m => !m.completed || m.decision === 'open');
+    const lastDecisionIndex = this.messagesSubject.value.findIndex(m => !m.completed || m.decision === "open");
     if (lastDecisionIndex >= 0) {
-      this.messagesSubject.value.splice(lastDecisionIndex, 0, newMessage)
+      this.messagesSubject.value.splice(lastDecisionIndex, 0, newMessage);
     } else {
-      this.messagesSubject.value.push(newMessage)
+      this.messagesSubject.value.push(newMessage);
     }
     this.messagesSubject.next(this.messagesSubject.value);
   }
 
   pushUser(recording: Recording) {
-    const newMessage = this.createCompletedMessage(recording.content, 'user', 'open', null);
+    const newMessage = this.createCompletedMessage(recording.content, "user", "open", null);
     this.messagesSubject.value.push(newMessage);
     this.messagesSubject.next(this.messagesSubject.value);
   }
@@ -204,7 +204,7 @@ export class ConversationService {
     this.speaker.push(message.role, message.text).then(() => {
       message.played = true;
       this.messagesSubject.next(this.messagesSubject.value);
-    })
+    });
   }
 
   push(recognition: OngoingRecognition, insertAt?: number) {
@@ -212,8 +212,8 @@ export class ConversationService {
       id: Date.now(),
       text$: recognition.text$,
       completed: false,
-      role: recognition.role,
-    }
+      role: recognition.role
+    };
 
     let currentIndex = insertAt ?? this.messagesSubject.value.length;
 
@@ -221,10 +221,18 @@ export class ConversationService {
       insertAt: currentIndex,
       recognition,
       subscription: recognition.completed.subscribe(completed => {
-        const message = this.createCompletedMessage(completed, recognition.role, 'open', recognition.textPrefix ?? null)
+        const message = this.createCompletedMessage(completed, recognition.role, "open", recognition.textPrefix ?? null);
         this.messagesSubject.value.push(message);
+
+        const index = this.messagesSubject.value.indexOf(ongoingMessage);
+        if (index >= 0) {
+          this.messagesSubject.value.splice(index, 1);
+          this.messagesSubject.value.push(ongoingMessage);
+        }
+        
         this.messagesSubject.next(this.messagesSubject.value);
-        currentIndex++
+
+        currentIndex++;
       })
     };
 
@@ -234,7 +242,7 @@ export class ConversationService {
 
     recognition.end.then(() => {
       ongoingConversation.subscription?.unsubscribe();
-      const index = this.ongoingConversations.indexOf(ongoingConversation)
+      const index = this.ongoingConversations.indexOf(ongoingConversation);
       if (index >= 0) {
         this.ongoingConversations.splice(index, 1);
       }
@@ -244,15 +252,15 @@ export class ConversationService {
         this.messagesSubject.value.splice(ongoingIndex, 1);
         this.messagesSubject.next(this.messagesSubject.value);
       }
-    })
+    });
   }
 
   private isExpandable(role: ConversationRole, text: string) {
-    return role === 'system' && text.length > this.messageMaxLength;
+    return role === "system" && text.length > this.messageMaxLength;
   }
 
   private getDisplayText(role: ConversationRole, text: string) {
-    return this.isExpandable(role, text) ? text.substring(0, this.messageMaxLength) + '...' : text;
+    return this.isExpandable(role, text) ? text.substring(0, this.messageMaxLength) + "..." : text;
   }
 
   private createCompletedMessage(
@@ -269,9 +277,9 @@ export class ConversationService {
       queued: false,
       role,
       completed: true,
-      prefix,
+      prefix
     };
-    if (!this.highlightSubject.value && decision === 'open') {
+    if (!this.highlightSubject.value && decision === "open") {
       newMessage.highlight = true;
       this.highlightSubject.next(newMessage);
     }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  overscroll-behavior: none;
+}


### PR DESCRIPTION
gian had some issues today. 
- longer prescripts broke the overall scrollbehavior. 
- he could not remove prescripts anymore
- the new input field blocked him from using space/backspace while accidentally being in focus

moved the developer toggles into the configuration panel and allowed a mode where there is not additional input.
there are now three stages that can be toggled.
1. Save mode, no distractions :) 
2. Override mode, input field for editing, modify presets
3. Live edit mode, allow removable of prescripts and additional actions in main area / conversation

<img width="1211" alt="Screenshot 2023-05-12 at 19 34 36" src="https://github.com/no0dles/chan-da-liar/assets/14818450/abe32fd8-c404-4589-b864-652269daea01">
<img width="1215" alt="Screenshot 2023-05-12 at 19 34 30" src="https://github.com/no0dles/chan-da-liar/assets/14818450/6cc2a671-fc01-4cf7-b796-d438bdd19844">
<img width="1213" alt="Screenshot 2023-05-12 at 19 34 26" src="https://github.com/no0dles/chan-da-liar/assets/14818450/7aed63ba-6588-4559-afe1-bb044a37657e">

